### PR TITLE
[add] IOScope.launchに値を返さないブロックへの対応を追加

### DIFF
--- a/io-type/scope-processor/src/main/kotlin/com/wsr/knist/scope/processor/ScopeOpProcessor.kt
+++ b/io-type/scope-processor/src/main/kotlin/com/wsr/knist/scope/processor/ScopeOpProcessor.kt
@@ -69,14 +69,7 @@ class ScopeOpProcessor(private val codeGenerator: CodeGenerator, private val log
         sb.appendLine("    companion object {")
         sb.appendLine("        // 二重ラップ防止用(context parameterで優先順位を整える)")
         sb.appendLine("        context(scope: IOScope)")
-        sb.appendLine("        @kotlin.OverloadResolutionByLambdaReturnType")
-        sb.appendLine("        inline fun <T : IOType> launch(block: IOScope.() -> T): T = scope.block()")
-        sb.appendLine("        context(scope: IOScope)")
-        sb.appendLine("        @kotlin.jvm.JvmName(\"launchBatch\")")
-        sb.appendLine("        @kotlin.OverloadResolutionByLambdaReturnType")
-        sb.appendLine(
-            "        inline fun <T : com.wsr.knist.batch.Batch<out IOType>> launch(block: IOScope.() -> T): T = scope.block()",
-        )
+        sb.appendLine("        inline fun <T> launch(block: IOScope.() -> T): T = scope.block()")
         sb.appendLine("    }")
 
         indexed.forEach { (_, data) ->
@@ -85,23 +78,16 @@ class ScopeOpProcessor(private val codeGenerator: CodeGenerator, private val log
 
         sb.appendLine("}")
 
-        sb.appendLine("@kotlin.OverloadResolutionByLambdaReturnType")
-        sb.appendLine("inline fun <T : IOType> IOScope.Companion.launch(block: IOScope.() -> T): T {")
+        sb.appendLine("inline fun <T> IOScope.Companion.launch(block: IOScope.() -> T): T {")
         sb.appendLine("    val bufferScope = BufferScope()")
         sb.appendLine("    val ioScope = IOScope(bufferScope)")
         sb.appendLine("    return bufferScope.use {")
-        sb.appendLine("        ioScope.block().also { bufferScope.remove(it.value) }")
-        sb.appendLine("    }")
-        sb.appendLine("}")
-        sb.appendLine("@kotlin.jvm.JvmName(\"launchBatch\")")
-        sb.appendLine("@kotlin.OverloadResolutionByLambdaReturnType")
-        sb.appendLine(
-            "inline fun <T : com.wsr.knist.batch.Batch<out IOType>> IOScope.Companion.launch(block: IOScope.() -> T): T {",
-        )
-        sb.appendLine("    val bufferScope = BufferScope()")
-        sb.appendLine("    val ioScope = IOScope(bufferScope)")
-        sb.appendLine("    return bufferScope.use {")
-        sb.appendLine("        ioScope.block().also { bufferScope.remove(it.value) }")
+        sb.appendLine("        val result = ioScope.block()")
+        sb.appendLine("        when (result) {")
+        sb.appendLine("            is IOType -> bufferScope.remove(result.value)")
+        sb.appendLine("            is com.wsr.knist.batch.Batch<*> -> bufferScope.remove(result.value)")
+        sb.appendLine("        }")
+        sb.appendLine("        result")
         sb.appendLine("    }")
         sb.appendLine("}")
 

--- a/io-type/src/commonTest/kotlin/com/wsr/knist/core/IOScopeTest.kt
+++ b/io-type/src/commonTest/kotlin/com/wsr/knist/core/IOScopeTest.kt
@@ -68,7 +68,7 @@ class IOScopeTest {
     }
 
     @Test
-    fun `launch(Unit版)内のバッファはscope終了後にreleaseされる`() = ioTypeTestRule {
+    fun `launchでUnitを返す場合バッファはscope終了後にreleaseされる`() = ioTypeTestRule {
         val buffer = TrackingDataBuffer(4)
         IOScope.launch {
             bufferScope.register(buffer)
@@ -77,7 +77,7 @@ class IOScopeTest {
     }
 
     @Test
-    fun `launch(Unit版)内で例外が発生してもバッファはreleaseされる`() = ioTypeTestRule {
+    fun `launchでUnitを返す場合で例外が発生してもバッファはreleaseされる`() = ioTypeTestRule {
         val buffer = TrackingDataBuffer(4)
         assertFails {
             IOScope.launch {

--- a/io-type/src/commonTest/kotlin/com/wsr/knist/core/IOScopeTest.kt
+++ b/io-type/src/commonTest/kotlin/com/wsr/knist/core/IOScopeTest.kt
@@ -68,6 +68,27 @@ class IOScopeTest {
     }
 
     @Test
+    fun `launch(Unit版)内のバッファはscope終了後にreleaseされる`() = ioTypeTestRule {
+        val buffer = TrackingDataBuffer(4)
+        IOScope.launch {
+            bufferScope.register(buffer)
+        }
+        assertTrue(buffer.released)
+    }
+
+    @Test
+    fun `launch(Unit版)内で例外が発生してもバッファはreleaseされる`() = ioTypeTestRule {
+        val buffer = TrackingDataBuffer(4)
+        assertFails {
+            IOScope.launch {
+                bufferScope.register(buffer)
+                throw RuntimeException("test")
+            }
+        }
+        assertTrue(buffer.released)
+    }
+
+    @Test
     fun `matMulをtransB=trueのみ指定してもIOScope版が呼ばれる`() = ioTypeTestRule {
         val ioScope = IOScope(BufferScope())
         val a = IOType.d2(2, 3) { _, _ -> 1f }


### PR DESCRIPTION
## チェックリスト

- [ ] 不必要なコードを削除する(コマンドラインからPushする場合)
- [ ] プルリクエストの名前を変更する
- [ ] 下の欄を埋める

# 概要

### 実装したところ

### 懸念点
